### PR TITLE
Add Stack section and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-fastapi service for machine learning.
+# mlapi
+
+FastAPI service for machine learning inference.
+
+## Stack
+
+Consumed by vortai and thread.
+
+## License
+
+MIT.


### PR DESCRIPTION
Minimum README: identifies mlapi as inference layer consumed by vortai and thread.